### PR TITLE
Perhaps a bug?

### DIFF
--- a/src/main/java/lollipop/listeners/LeaderboardListener.java
+++ b/src/main/java/lollipop/listeners/LeaderboardListener.java
@@ -29,6 +29,7 @@ public class LeaderboardListener extends ListenerAdapter {
         if (!event.getMember().getId().equals(id[0])) {
             event.reply("You are not the one who requested the leaderboard. Use `/leaderboard` to create a new one.")
                     .setEphemeral(true).queue();
+            return;
         }
 
         Message message = event.getMessage();


### PR DESCRIPTION
found out by Zone-infinity.
Bug: Leaderboard could be modified by users other than the one that used the command in the first place despite warning saying they are not allowed to due to them not being the one to create the leaderboard instance.